### PR TITLE
Add the Travis Ci configuration

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,32 @@
+# Tell Travis CI we are using PHP
+language: php
+# The platforms you wants to test on
+dist: bionic
+os:
+  - linux
+# Define the php versions against we want to test our code
+php:
+  - '7.3'
+
+# Install packages those will be required during build
+install:
+  - composer install --no-interaction
+
+# Run main commands
+script:
+  - vendor/bin/codecept run unit,api
+#  - make run-tests-unit
+#  - make run-tests-api
+#  - make run-tests-acceptance
+
+# Tell Travis CI to monitor only 'master' branch
+branches:
+  only: 
+    - master
+    - feature/travis-continuous-integration
+
+# Cache folder, you can delete cache from Travis CI web interface
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 Two docker containers:
   - api-php : PHP 7.3 / Symfony 5.X
   - api-nginx : NGINX 1.17
+  
 
 ## Test
 
-[codeception](https://codeception.com/) to run all the tests
+Adding the `docker-compose.test.yaml` you can run the tests 
+via a [codeception](https://codeception.com/) container named `api-test` 
 
 ```bash
 make run-tests-all


### PR DESCRIPTION
| Q | A |
| - | - |
| Bug Fix ? | no |
| New Feature ? | yes |
| Issue | #4 |
 
Checklist:

- [x] Bug fix are covered by unit tests 
- [x] New feature are covered by unit,api and acceptance tests
- [x] All tests passed
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This feature adds the Travis Continuous Integration configuration
The CI steps are : 
1. `make run-tests-unit`
2. `make run-tests-api`
3. `make run-tests-acceptance`