### PR TITLE
Improve the 'dev' mode versus the 'prod' mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,21 +76,17 @@ ARG ARG_APP_ENV=prod
 ENV APP_ENV=$ARG_APP_ENV
 
 # prevent the reinstallation of vendors at every changes in the source code
-COPY composer.json composer.lock symfony.lock ./
+COPY .env composer.json composer.lock symfony.lock ./
 RUN set -eux; \
-	composer install --prefer-dist --no-dev --no-scripts --no-progress --no-suggest; \
+	composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress --no-suggest; \
 	composer clear-cache
 
-# do not use .env files in production
-COPY .env ./
-RUN composer dump-env ${APP_ENV}; \
-	rm .env
-
-# copy only specifically what we need
+# Copy only specifically what we need
 COPY bin bin/
 COPY config config/
 COPY public public/
 COPY src src/
+COPY templates templates/
 
 RUN set -eux; \
 	mkdir -p var/cache var/log; \

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -2,9 +2,6 @@ version: '3.7'
 
 services:
   api-php:
-    build:
-      args: 
-        ARG_APP_ENV: dev  
     env_file:
       - .env.dev
     volumes:

--- a/docker.env
+++ b/docker.env
@@ -7,7 +7,7 @@
 COMPOSE_PROJECT_NAME=myproject
 
 # The docker-compose commands
-DOCKER_COMPOSE=docker-compose -p $(COMPOSE_PROJECT_NAME)
+DOCKER_COMPOSE=docker-compose -p $(COMPOSE_PROJECT_NAME) -f docker-compose.yaml
 DOCKER_COMPOSE_EXEC=$(DOCKER_COMPOSE) exec
 DOCKER_COMPOSE_LOGS=$(DOCKER_COMPOSE) logs --tail=100
 DOCKER_COMPOSE_UP=$(DOCKER_COMPOSE) up

--- a/docker.env.local
+++ b/docker.env.local
@@ -1,0 +1,1 @@
+#DOCKER_COMPOSE=docker-compose -p $(COMPOSE_PROJECT_NAME) -f docker-compose.yaml -f docker-compose.override.yaml

--- a/tests/api/HealthCest.php
+++ b/tests/api/HealthCest.php
@@ -16,6 +16,6 @@ class HealthCest
         $I->sendGET('/health');
         $I->seeResponseCodeIs(HttpCode::OK);
         $I->seeHttpHeaderOnce('Content-Type', 'text/plain');
-        $I->seeResponseContains('healthy');
+        $I->seeResponseEquals('healthy');
     }
 }

--- a/tests/api/PingCest.php
+++ b/tests/api/PingCest.php
@@ -16,6 +16,6 @@ class PingCest
         $I->sendGET('/ping');
         $I->seeResponseCodeIs(HttpCode::OK);
         $I->seeHttpHeaderOnce('Content-Type', 'text/plain');
-        $I->seeResponseContains('pong');
+        $I->seeResponseEquals('pong');
     }
 }


### PR DESCRIPTION
| Q | A |
| - | - |
| Bug Fix ? | yes |
| New Feature ? | no |
| Issue | #2 |
 
Checklist:

- [x] Bug fix are covered by unit tests 
- [x] New feature are covered by unit,api and acceptance tests
- [x] All tests passed
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
The change improve the switch between the `dev` mode and the `prod` mode (enable the `docker.env.local` commands)